### PR TITLE
[MWPW-126441] Unblock style-linting by lowercasing all t-shirt sizes in classnames

### DIFF
--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -129,8 +129,8 @@ const init = async (el) => {
 
   el.append(nav);
   el.classList.add(`${isAccordion ? 'accordion' : 'simple'}`);
-  topList.classList.add('top-list', 'body-S');
-  title?.classList.add('title', 'heading-XS');
+  topList.classList.add('top-list', 'body-s');
+  title?.classList.add('title', 'heading-xs');
 
   if (currentLinks.length === 1) { currentLinks[0].classList.add('current-page'); }
 


### PR DESCRIPTION
* NOTE: This PR relates directly to [#503 in the milo repo](https://github.com/adobecom/milo/pull/503) and SHOULD NOT be merged until the PR in milo is merged and then consumed here.
* Updates all JS files that set classnames to use lowercase t-shirt sizes
* Should allow us to get a clearer picture of style-linting errors moving forward

Resolves: [MWPW-126441](https://jira.corp.adobe.com/browse/MWPW-126441)

**Test URLs:**
(Note that these should both look the same, but the After view uses lowercase t-shirt size classnames)
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/media?martech=off
- After: https://ebartholomew-kebab-case-tshirts--milo--adobecom.hlx.page/docs/library/blocks/media?martech=off
