### PR TITLE
fix side nav stick position when used inside a fragment

### DIFF
--- a/blocks/tree-view/tree-view.css
+++ b/blocks/tree-view/tree-view.css
@@ -5,10 +5,6 @@
   top: 100px;
 }
 
-.fragment > .section > .tree-view {
-  position: fixed;
-}
-
 .tree-view .title {
   text-transform: none !important;
   font-weight: bold;

--- a/blocks/tree-view/tree-view.css
+++ b/blocks/tree-view/tree-view.css
@@ -5,6 +5,10 @@
   top: 100px;
 }
 
+.fragment > .section > .tree-view {
+  position: fixed;
+}
+
 .tree-view .title {
   text-transform: none !important;
   font-weight: bold;

--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -194,6 +194,10 @@ const init = async (el) => {
       subListItem.role = 'presentation';
     });
   }
+
+  if(el.parentElement.parentElement.className === 'fragment'){
+    el.parentElement.style.height= '100vh'
+  }
 };
 
 export default init;

--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -194,9 +194,28 @@ const init = async (el) => {
       subListItem.role = 'presentation';
     });
   }
+  
+  function debounce(func){
+    let timer;
+    return function(event){
+      if(timer) clearTimeout(timer);
+      timer = setTimeout(func,100,event);
+    };
+  }
 
   if(el.parentElement.parentElement.className === 'fragment'){
-    el.parentElement.style.height= '100vh'
+
+    setTimeout(() => {
+      const contentSectionHeight = document.getElementsByClassName('content')[0].offsetHeight
+      const vhValue = 100 * contentSectionHeight / window.innerHeight
+      el.parentElement.style.height= vhValue +'vh'
+    }, "500");
+  
+    window.addEventListener('resize', debounce(function() {
+      const contentSectionHeight = document.getElementsByClassName('content')[0].offsetHeight
+      const vhValue = 100 * contentSectionHeight / window.innerHeight
+      el.parentElement.style.height= vhValue +'vh'
+     }));
   }
 };
 


### PR DESCRIPTION
**Jira Ticket:**
https://jira.corp.adobe.com/browse/ABPDOCS-201

**Description**
Side nav stick position was not working with fragment . This PR adds a new css block to the tree-view codebase so that the descendent child of fragment gets a new position element. This sticks the side nav to the top of the page during the scroll.

Working example: 
https://main--abpdocs--adobecom.hlx.page/archive/test/how-it-works

Preview link:
https://kakyigit-abpdocs-201--abpdocs--adobecom.hlx.page/archive/test/gtm101
https://kakyigit-abpdocs-201--abpdocs--adobecom.hlx.page/archive/test/aid-onboarding
