### PR TITLE
Move controls to the abp-controls to the content section

### DIFF
--- a/blocks/abp-controls/abp-controls.css
+++ b/blocks/abp-controls/abp-controls.css
@@ -1,7 +1,6 @@
 .abp-controls {
   display: flex;
   padding: 10px;
-  margin: 0 auto;
   max-width: 1200px;
   justify-content: space-between;
 }


### PR DESCRIPTION
**Description:**
Remove the unwanted margin auto, to adjust the position of the controls on the content section.

**Preview Links:** 
- https://kakyigit-fix-controls--abpdocs--adobecom.hlx.page/archive/test/ais-support
- https://kakyigit-fix-controls--abpdocs--adobecom.hlx.page/onboarding-template