### PR TITLE
Update styles.css to fix the search and column headers

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -59,3 +59,24 @@ span.icon.icon-info {
 .columns.columns-table > .row:first-child  {
     color: gray ;
 }
+
+.gnav-search-results .article-card-body h3 {
+    min-height: inherit;
+}
+
+.gnav-search-results > ul li > a p {
+	font-weight: normal;
+}
+
+.gnav-search-results .article-card .article-card-image {
+	height: 0px;
+}
+
+.gnav-search-results .article-card .article-card-image img {
+	display: none;
+	height: 0px;
+}
+
+.columns.columns-table > .row:first-child {
+ text-transform: none !important;
+}


### PR DESCRIPTION
Update styles.css to fix the search to hide images and column headers with no text-transformation

![image](https://github.com/adobecom/abpdocs/assets/76102351/a913c6d6-f5a3-483a-b4c4-3b66c28817cb)

![image](https://github.com/adobecom/abpdocs/assets/76102351/9faacf56-261c-457b-a98f-8825d1f7a68b)

