### PR TITLE
Migrate to hlx-5

### DIFF
--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -1,6 +1,6 @@
 import { getLibs } from '../../scripts/utils.js';
 
-const BACOM_HOSTS = ['localhost', '--abpdocs--adobecom.hlx.page', '--abpdocs--adobecom.hlx.live', 'abp.adobe.com'];
+const BACOM_HOSTS = ['localhost', '--abpdocs--adobecom.hlx.page', '--abpdocs--adobecom.hlx.live', '--abpdocs--adobecom.aem.page', '--abpdocs--adobecom.aem.live', 'abp.adobe.com'];
 
 export const isCurrentPage = (link) => {
   const currentPath = window.location.pathname.replace('.html', '');

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -24,8 +24,8 @@ export const [setLibs, getLibs] = (() => {
   return [
     (prodLibs) => {
       const { hostname } = window.location;
-      if (!hostname.includes('hlx.page')
-        && !hostname.includes('hlx.live')
+      if (!hostname.includes('.page')
+        && !hostname.includes('.live')
         && !hostname.includes('localhost')) {
         libs = prodLibs;
       } else {
@@ -33,9 +33,9 @@ export const [setLibs, getLibs] = (() => {
         if (branch === 'local') {
           libs = 'http://localhost:6456/libs';
         } else if (branch.indexOf('--') > -1) {
-          libs = `https://${branch}.hlx.page/libs`;
+          libs = `https://${branch}.aem.page/libs`;
         } else {
-          libs = `https://${branch}--milo--adobecom.hlx.page/libs`;
+          libs = `https://${branch}--milo--adobecom.aem.page/libs`;
         }
       }
       return libs;

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -26,8 +26,8 @@ function hasSchema(host) {
       {
         text: 'Blocks',
         paths: [
-          'https://main--milo--adobecom.hlx.page/docs/library/blocks.json',
-          'https://main--college--adobecom.hlx.page/docs/library/blocks.json',
+          'https://main--milo--adobecom.aem.page/docs/library/blocks.json',
+          'https://main--college--adobecom.aem.page/docs/library/blocks.json',
         ],
       },
     ],
@@ -39,7 +39,7 @@ function hasSchema(host) {
         button: {
           text: 'Library',
           action: (_, s) => {
-            const domain = 'https://main--milo--adobecom.hlx.page';
+            const domain = 'https://main--milo--adobecom.aem.page';
             const { config } = s;
             const script = document.createElement('script');
             script.onload = () => {


### PR DESCRIPTION
### Description
Migrate to hlx-5 

Ticket: https://jira.corp.adobe.com/browse/MWPW-169747

### Notes
I discovered that the review block is a 401 which won't get better since after this upgrade the forms service is not usable anymore on hlx-5, however that's a preexisting issue outside of the scope of this migration. I'll flag this separately with the stakeholders.

Before: https://main--abpdocs--adobecom.hlx.live/playbooks/upp/overview
After: https://hlx-5--abpdocs--adobecom.hlx.live/playbooks/upp/overview
After-2: https://hlx-5--abpdocs--adobecom.aem.live/playbooks/upp/overview